### PR TITLE
Added mongodb backend to proto1

### DIFF
--- a/proto1/package.json
+++ b/proto1/package.json
@@ -11,6 +11,7 @@
     "cors": "^2.8.4",
     "express": "^4.15.3",
     "font-awesome": "^4.7.0",
+    "mongodb": "^2.2",
     "mingo": "^1.3.3",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/proto1/server/livedb.js
+++ b/proto1/server/livedb.js
@@ -6,6 +6,10 @@ class LiveDB {
         this._live_queries = [];
     }
 
+    connect(callback) {
+	callback();
+    }
+
     generateID() {
         return "did_" + Math.floor(Math.random() * 10000);
     }

--- a/proto1/server/persistdb.js
+++ b/proto1/server/persistdb.js
@@ -1,0 +1,144 @@
+const Mongo = require('mongodb');
+const util = require('util')
+
+class LiveDB {
+    constructor() {
+	this.url = 'mongodb://localhost:27017/idealos';
+        this._live_queries = [];
+    }
+
+    connect(callback) {
+	const self = this;
+	Mongo.connect(this.url, function(err, db) {
+	    if (err !== null) {
+		throw err;
+	    }
+	    console.log('Connected to persistent db');
+	    self.db = db;
+	    callback();
+	});
+    }
+
+    importDocs(docs) {
+	this.db.collection('docs').insertMany(docs, ((err, docsInserted) => {
+	    docsInserted.ops.forEach((doc) => {
+               this._live_queries.forEach((lq)=>{
+                  if(lq.matches(doc)) {
+                     lq.fireInsert([doc]);
+                  }
+               });
+	    });
+	}));
+    }
+
+    reset() {
+	this.db.collection('docs').remove();
+        this._live_queries = [];
+    }
+
+    insert(doc) {
+        this.importDocs([doc]);
+        return Promise.resolve(doc);
+    }
+
+    update(doc) {
+	const self = this;
+	return new Promise((resolve, reject) => {
+  	    this.db.collection('docs').updateOne({"_id": doc._id}, {$set: doc}, function(err, r) {
+	        if (err !== null) {
+         	    reject(err);
+	        } else {
+		    self._live_queries.forEach((lq)=>{
+		        if(lq.matches(doc)) lq.fireInsert([doc]);
+		    });
+		    resolve(doc);
+	        }
+	    });
+	});
+    }
+
+    delete(doc) {
+	return new Promise((resolve, reject) => {
+ 	    this.db.collection('docs').deleteOne({"_id": doc._id}, function(err, r) {
+	        if (err !== null) {
+	    	    reject(err);
+	        } else {
+		    this._live_queries.forEach((lq)=>{
+		        if(lq.matches(doc)) lq.fireInsert([doc]);
+		    });
+		    resolve(doc);
+	        }
+	   });
+	});
+    }
+
+    query(q) {
+	return new Promise((resolve, reject) => {
+  	    this.db.collection('docs').find(q).toArray(function(err, docs){
+		if (err !== null) {
+		    reject(err);
+		} else {
+	           resolve(docs);
+		}
+	    });
+	});
+    }
+
+    makeLiveQuery(q) {
+        let lq = new LiveQuery(q,this);
+        this._live_queries.push(lq);
+        return lq;
+    }
+
+    updateLiveQuery(queryId,q) {
+        let lq = this._live_queries.find((q)=>q.id === queryId);
+        lq.updateQuery(q);
+    }
+
+}
+
+class LiveQuery {
+    constructor(q, db) {
+	this.q = q;
+        this.db = db;
+        this.cbs = [];
+        this.id = "id_"+Math.floor(Math.random()*10000);
+        this.docs = [];
+    }
+    on(type,cb) {
+        this.cbs.push(cb);
+    }
+    matches(doc) {
+	const q = this.q;
+	Object.keys(q).forEach(function(key) {
+	    if (q[key] !== doc[key]) {
+		return false;
+	    }
+	});
+        return true;
+    }
+    fireInsert(docs) {
+        this.execute();
+    }
+    fireRemove(docs) {
+        this.execute();
+    }
+    fireDelete(docs) {
+        this.execute();
+    }
+    updateQuery(q) {
+        this.q = q;
+        this.execute();
+    }
+    execute() {
+        this.db.query(this.q).then((docs) => {
+	    this.docs = docs;
+            this.cbs.forEach((cb)=>cb(this.id,this.docs));
+	});
+    }
+}
+module.exports = {
+    make: function() {
+        return new LiveDB();
+    }
+};


### PR DESCRIPTION
Josh,

I've added a persistdb.js to the server which expects mongodb to be running on localhost port 27017 (the default port).  There are two command line parameters:

mongo - use the mongo database
reload - clear & reload the database on start

Still needs more testing, and the live queries aren't being saved yet, but I thought I'd send it to you to see what you thought

Keith